### PR TITLE
Pin dependencies

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -1,16 +1,13 @@
 channels:
   - conda-forge
 dependencies:
-  - python=3.12
-  - pre_commit>=4.0.1
-  - ruff>=0.6.9
-  - pip>=24.3.1
-
   # Notebook pub infrastructure
-  - jupyterlab>=4.2.5
-  - matplotlib>=3.9.2
-  - pyyaml>=6.0.2
-  - pandas>=2.2.3
+  - python=3.12
+  - pre_commit=4.0.1
+  - ruff=0.6.9
+  - pip=24.3.1
+  - jupyterlab=4.2.5
+  - pyyaml=6.0.2
 
   # Added dependencies
   - natsort=8.4.0
@@ -20,14 +17,16 @@ dependencies:
   - scipy=1.14.1
   - scikit-learn=1.6.1
   - tqdm=4.66.5
+  - matplotlib=3.9.2
+  - pandas=2.2.3
 
   - pip:
       # Notebook pub infrastructure
       - jupyterlab-quarto==0.3.5
 
       # Added dependencies
-      - plotly>=5.24.1
-      - arcadia-pycolor>=0.5.1
+      - plotly==5.24.1
+      - arcadia-pycolor==0.5.1
       - ipywidgets==8.1.5
       - lmfit==1.3.2
       - git+https://github.com/Arcadia-Science/ramanalysis.git@f515955


### PR DESCRIPTION
I'm not sure why this occurs, but when I build the environment the plotly figures don't show up. My guess is that it's because of a major Plotly release. For the time being, better to pin plotly to <6.X.X.

And to avoid other mishaps, I figured we should pin all the dependencies. It might be worth rebuilding your environment and verifying this works and renders the pub, using this new `env.yml`.