### PR TITLE
Update .gitignore -- ignore Adobe illustrator files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,6 @@ cython_debug/
 /.quarto/
 /_site/
 /*_files/
+
+# Adobe illustrator
+*.ai


### PR DESCRIPTION
This PR adds Adobe illustrator files (`*.ai`) to the gitignore.